### PR TITLE
feat: implement core game mechanics with session management and credit flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,10 @@ npm run dev
 - **Swagger API Documentation Setup**: Implemented comprehensive Swagger documentation for all API endpoints with proper decorators, response types, and authentication requirements. The interactive API documentation is available at `/api/docs` and includes detailed descriptions, request/response examples, and the ability to test endpoints directly from the browser interface.
 
 - **Configuration Management Setup (10min)**: Implemented centralized configuration using `@nestjs/config` to replace scattered `process.env` usage throughout the codebase. This provides better type safety, centralized configuration, and easier environment switching.
+
+- **Main Game Session Logic Implementation (2h)**: Designed and implemented the core game mechanics with a balance management system:
+  - **Balance Architecture**: I decided to implement a two-tier balance system where users have an overall balance that allocates 10 credits to each new session. This approach provides better control over credit distribution and prevents players from creating multiple sessions to exploit the system.
+  - **Session Lifecycle Management**: I created a complete session management system where users can start a new game session, perform rolls during the session, and cash out when finished. Each roll result is stored in the database to have the game history.
+  - **Credit Flow System**: I implemented a credit flow mechanism where credits are deducted from the session balance for each roll, and upon cash out, the remaining session balance is transferred back to the user's overall balance. This ensures credit tracking and prevents credit loss.
+  - **Game Configuration Centralization**: I decided to move all game-related configuration (symbol rewards, cheating thresholds, cheating probabilities) to the application configuration module. This makes it easy to adjust game parameters like cheating behavior or winning credit amounts without services code changes, simply by modifying configuration file.
+  - **Database Integration**: I set up database entities and repositories for game sessions and game rolls to maintain game state and provide game history tracking.

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -4,6 +4,7 @@ import { DatabaseModule } from "./database/database.module";
 import { AuthModule } from "./auth/auth.module";
 import { UserModule } from "./user/user.module";
 import { HealthModule } from "./health/health.module";
+import { GameModule } from "./game/game.module";
 import configuration from "./config/configuration";
 
 @Module({
@@ -17,6 +18,7 @@ import configuration from "./config/configuration";
     AuthModule,
     UserModule,
     HealthModule,
+    GameModule,
   ],
 })
 export class AppModule {}

--- a/service/src/config/app.config.ts
+++ b/service/src/config/app.config.ts
@@ -1,10 +1,58 @@
 import { registerAs } from "@nestjs/config";
+import { RollSymbol } from "src/database/entities/game-roll.entity";
 
-export default registerAs("app", () => ({
-  port: parseInt(process.env.PORT, 10) || 4000,
-  apiPrefix: process.env.API_PREFIX || "api/v1",
+export interface CheatingThreshold {
+  balance: number;
+  rerollChance: number;
+}
+
+export interface CheatingConfig {
+  enabled: boolean;
+  thresholds: CheatingThreshold[];
+}
+
+export interface AppConfig {
+  port: number;
+  apiPrefix: string;
   jwt: {
-    secret: process.env.JWT_SECRET || "your-super-secret-jwt-key",
-    expiresIn: process.env.JWT_EXPIRES_IN || "24h",
-  },
-}));
+    secret: string;
+    expiresIn: string;
+  };
+  game: {
+    defaultUserCredits: number;
+    sessionStartingCredits: number;
+    symbolsCount: number;
+    symbolRewards: Record<RollSymbol, number>;
+    cheating: CheatingConfig;
+  };
+}
+
+export default registerAs(
+  "app",
+  (): AppConfig => ({
+    port: parseInt(process.env.PORT, 10) || 4000,
+    apiPrefix: process.env.API_PREFIX || "api/v1",
+    jwt: {
+      secret: process.env.JWT_SECRET || "your-super-secret-jwt-key",
+      expiresIn: process.env.JWT_EXPIRES_IN || "24h",
+    },
+    game: {
+      defaultUserCredits: 10,
+      sessionStartingCredits: 10,
+      symbolsCount: 3,
+      symbolRewards: {
+        [RollSymbol.CHERRY]: 10,
+        [RollSymbol.LEMON]: 20,
+        [RollSymbol.ORANGE]: 30,
+        [RollSymbol.WATERMELON]: 40,
+      },
+      cheating: {
+        enabled: true,
+        thresholds: [
+          { balance: 40, rerollChance: 0.3 },
+          { balance: 60, rerollChance: 0.6 },
+        ],
+      },
+    },
+  })
+);

--- a/service/src/database/database.module.ts
+++ b/service/src/database/database.module.ts
@@ -1,9 +1,21 @@
 import { Module } from "@nestjs/common";
 import { DatabaseService } from "./database.service";
 import { UserRepository } from "./user.repository";
+import { GameSessionRepository } from "./game-session.repository";
+import { GameRollRepository } from "./game-roll.repository";
 
 @Module({
-  providers: [DatabaseService, UserRepository],
-  exports: [DatabaseService, UserRepository],
+  providers: [
+    DatabaseService,
+    UserRepository,
+    GameSessionRepository,
+    GameRollRepository,
+  ],
+  exports: [
+    DatabaseService,
+    UserRepository,
+    GameSessionRepository,
+    GameRollRepository,
+  ],
 })
 export class DatabaseModule {}

--- a/service/src/database/entities/game-roll.entity.ts
+++ b/service/src/database/entities/game-roll.entity.ts
@@ -1,0 +1,39 @@
+export enum RollSymbol {
+  CHERRY = "CHERRY",
+  LEMON = "LEMON",
+  ORANGE = "ORANGE",
+  WATERMELON = "WATERMELON",
+}
+
+export class GameRoll {
+  id: string;
+  sessionId: string;
+  symbols: RollSymbol[];
+  isWin: boolean;
+  reward: number;
+  creditsBefore: number;
+  creditsAfter: number;
+  wasRerolled: boolean;
+  createdAt: Date;
+
+  constructor(
+    id: string,
+    sessionId: string,
+    symbols: RollSymbol[],
+    isWin: boolean,
+    reward: number,
+    creditsBefore: number,
+    creditsAfter: number,
+    wasRerolled: boolean = false
+  ) {
+    this.id = id;
+    this.sessionId = sessionId;
+    this.symbols = symbols;
+    this.isWin = isWin;
+    this.reward = reward;
+    this.creditsBefore = creditsBefore;
+    this.creditsAfter = creditsAfter;
+    this.wasRerolled = wasRerolled;
+    this.createdAt = new Date();
+  }
+}

--- a/service/src/database/entities/game-session.entity.ts
+++ b/service/src/database/entities/game-session.entity.ts
@@ -1,0 +1,17 @@
+export class GameSession {
+  id: string;
+  userId: string;
+  credits: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(id: string, userId: string, credits: number = 10) {
+    this.id = id;
+    this.userId = userId;
+    this.credits = credits;
+    this.isActive = true;
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+  }
+}

--- a/service/src/database/entities/index.ts
+++ b/service/src/database/entities/index.ts
@@ -1,1 +1,3 @@
 export { User } from "./user.entity";
+export { GameSession } from "./game-session.entity";
+export { GameRoll, RollSymbol } from "./game-roll.entity";

--- a/service/src/database/game-roll.repository.ts
+++ b/service/src/database/game-roll.repository.ts
@@ -1,0 +1,48 @@
+import { Injectable } from "@nestjs/common";
+import { GameRoll, RollSymbol } from "./entities/game-roll.entity";
+import { v4 as uuidv4 } from "uuid";
+
+@Injectable()
+export class GameRollRepository {
+  private rolls: Map<string, GameRoll> = new Map();
+
+  create(
+    sessionId: string,
+    symbols: RollSymbol[],
+    isWin: boolean,
+    reward: number,
+    creditsBefore: number,
+    creditsAfter: number,
+    wasRerolled: boolean = false
+  ): GameRoll {
+    const id = uuidv4();
+    const roll = new GameRoll(
+      id,
+      sessionId,
+      symbols,
+      isWin,
+      reward,
+      creditsBefore,
+      creditsAfter,
+      wasRerolled
+    );
+    this.rolls.set(id, roll);
+    return roll;
+  }
+
+  findBySessionId(sessionId: string): GameRoll[] {
+    const sessionRolls: GameRoll[] = [];
+    for (const roll of this.rolls.values()) {
+      if (roll.sessionId === sessionId) {
+        sessionRolls.push(roll);
+      }
+    }
+    return sessionRolls.sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+    );
+  }
+
+  findById(id: string): GameRoll | null {
+    return this.rolls.get(id) || null;
+  }
+}

--- a/service/src/database/game-session.repository.ts
+++ b/service/src/database/game-session.repository.ts
@@ -1,0 +1,37 @@
+import { Injectable } from "@nestjs/common";
+import { GameSession } from "./entities/game-session.entity";
+import { v4 as uuidv4 } from "uuid";
+
+@Injectable()
+export class GameSessionRepository {
+  private sessions: Map<string, GameSession> = new Map();
+
+  create(userId: string, credits: number = 10): GameSession {
+    const id = uuidv4();
+    const session = new GameSession(id, userId, credits);
+    this.sessions.set(id, session);
+    return session;
+  }
+
+  findById(id: string): GameSession | null {
+    return this.sessions.get(id) || null;
+  }
+
+  findUserActiveSession(userId: string): GameSession | null {
+    for (const session of this.sessions.values()) {
+      if (session.userId === userId && session.isActive) {
+        return session;
+      }
+    }
+    return null;
+  }
+
+  closeSession(id: string): void {
+    const session = this.sessions.get(id);
+    if (session) {
+      session.isActive = false;
+      session.updatedAt = new Date();
+      this.sessions.set(id, session);
+    }
+  }
+}

--- a/service/src/database/user.repository.ts
+++ b/service/src/database/user.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { v4 as uuidv4 } from "uuid";
 import { User } from "./entities/user.entity";
 
@@ -6,9 +7,14 @@ import { User } from "./entities/user.entity";
 export class UserRepository {
   private users: Map<string, User> = new Map();
 
+  constructor(private configService: ConfigService) {}
+
   create(): User {
     const userId = uuidv4();
-    const user = new User(userId, 10);
+    const defaultCredits = this.configService.get(
+      "app.game.defaultUserCredits"
+    );
+    const user = new User(userId, defaultCredits);
     this.users.set(user.id, user);
     return user;
   }

--- a/service/src/game/dto/cashout-response.dto.ts
+++ b/service/src/game/dto/cashout-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CashoutResponseDto {
+  @ApiProperty({
+    description: "Session ID that was cashed out",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  sessionId: string;
+
+  @ApiProperty({
+    description: "Amount of credits cashed out from the session",
+    example: 45,
+  })
+  cashedOutCredits: number;
+
+  @ApiProperty({
+    description: "Cashout timestamp",
+    example: "2024-01-01T00:00:00.000Z",
+  })
+  cashedOutAt: Date;
+}

--- a/service/src/game/dto/roll-response.dto.ts
+++ b/service/src/game/dto/roll-response.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { RollSymbol } from "../../database/entities/game-roll.entity";
+
+export class RollResponseDto {
+  @ApiProperty({
+    description: "Roll ID",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  rollId: string;
+
+  @ApiProperty({
+    description: "Array of 3 symbols from the roll",
+    example: ["CHERRY", "CHERRY", "CHERRY"],
+    enum: RollSymbol,
+    isArray: true,
+  })
+  symbols: RollSymbol[];
+
+  @ApiProperty({
+    description: "Whether this roll was a win",
+    example: true,
+  })
+  isWin: boolean;
+
+  @ApiProperty({
+    description: "Reward amount for this roll",
+    example: 10,
+  })
+  reward: number;
+
+  @ApiProperty({
+    description: "Credits before the roll",
+    example: 10,
+  })
+  creditsBefore: number;
+
+  @ApiProperty({
+    description: "Credits after the roll",
+    example: 19,
+  })
+  creditsAfter: number;
+
+  @ApiProperty({
+    description: "Roll timestamp",
+    example: "2024-01-01T00:00:00.000Z",
+  })
+  createdAt: Date;
+}

--- a/service/src/game/dto/session-response.dto.ts
+++ b/service/src/game/dto/session-response.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SessionResponseDto {
+  @ApiProperty({
+    description: "Session ID",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  sessionId: string;
+
+  @ApiProperty({
+    description: "Current credits in the session",
+    example: 10,
+  })
+  credits: number;
+
+  @ApiProperty({
+    description: "Whether the session is active",
+    example: true,
+  })
+  isActive: boolean;
+
+  @ApiProperty({
+    description: "Session creation timestamp",
+    example: "2024-01-01T00:00:00.000Z",
+  })
+  createdAt: Date;
+}

--- a/service/src/game/game.controller.ts
+++ b/service/src/game/game.controller.ts
@@ -1,0 +1,167 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Request,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBearerAuth,
+} from "@nestjs/swagger";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { GameService } from "./game.service";
+import { SessionResponseDto } from "./dto/session-response.dto";
+import { RollResponseDto } from "./dto/roll-response.dto";
+import { CashoutResponseDto } from "./dto/cashout-response.dto";
+import { User } from "../database/entities/user.entity";
+
+@ApiTags("Game")
+@Controller("game")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class GameController {
+  constructor(private readonly gameService: GameService) {}
+
+  @Post("session/start")
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: "Start a new game session" })
+  @ApiResponse({
+    status: 201,
+    description: "Game session started successfully",
+    type: SessionResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: "User already has an active session or insufficient credits",
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Unauthorized",
+  })
+  async startSession(
+    @Request() req: { user: User }
+  ): Promise<SessionResponseDto> {
+    return this.gameService.startSession(req.user);
+  }
+
+  @Post("session/:sessionId/roll")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Pull the slot machine lever (make a roll)" })
+  @ApiParam({ name: "sessionId", description: "Game session ID" })
+  @ApiResponse({
+    status: 200,
+    description: "Roll completed successfully",
+    type: RollResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: "Insufficient credits to roll",
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Unauthorized",
+  })
+  @ApiResponse({
+    status: 403,
+    description: "Forbidden - You can only roll in your own session",
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Active session not found",
+  })
+  async roll(
+    @Param("sessionId") sessionId: string,
+    @Request() req: { user: User }
+  ): Promise<RollResponseDto> {
+    return this.gameService.roll(sessionId, req.user);
+  }
+
+  @Post("session/:sessionId/cashout")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "Cash out credits from the game session" })
+  @ApiParam({ name: "sessionId", description: "Game session ID" })
+  @ApiResponse({
+    status: 200,
+    description: "Cashout completed successfully",
+    type: CashoutResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Unauthorized",
+  })
+  @ApiResponse({
+    status: 403,
+    description: "Forbidden - You can only cash out your own session",
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Active session not found",
+  })
+  async cashout(
+    @Param("sessionId") sessionId: string,
+    @Request() req: { user: User }
+  ): Promise<CashoutResponseDto> {
+    return this.gameService.cashout(sessionId, req.user);
+  }
+
+  @Get("session/:sessionId")
+  @ApiOperation({ summary: "Get game session details" })
+  @ApiParam({ name: "sessionId", description: "Game session ID" })
+  @ApiResponse({
+    status: 200,
+    description: "Session details retrieved successfully",
+    type: SessionResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Unauthorized",
+  })
+  @ApiResponse({
+    status: 403,
+    description: "Forbidden - You can only view your own sessions",
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Session not found",
+  })
+  async getSession(
+    @Param("sessionId") sessionId: string,
+    @Request() req: { user: User }
+  ): Promise<SessionResponseDto> {
+    return this.gameService.getSession(sessionId, req.user);
+  }
+
+  @Get("session/:sessionId/rolls")
+  @ApiOperation({ summary: "Get all rolls for a game session" })
+  @ApiParam({ name: "sessionId", description: "Game session ID" })
+  @ApiResponse({
+    status: 200,
+    description: "Rolls retrieved successfully",
+    type: [RollResponseDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: "Unauthorized",
+  })
+  @ApiResponse({
+    status: 403,
+    description: "Forbidden - You can only view your own session rolls",
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Session not found",
+  })
+  async getSessionRolls(
+    @Param("sessionId") sessionId: string,
+    @Request() req: { user: User }
+  ): Promise<RollResponseDto[]> {
+    return this.gameService.getSessionRolls(sessionId, req.user);
+  }
+}

--- a/service/src/game/game.module.ts
+++ b/service/src/game/game.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { GameController } from "./game.controller";
+import { GameService } from "./game.service";
+import { DatabaseModule } from "../database/database.module";
+import { AuthModule } from "../auth/auth.module";
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [GameController],
+  providers: [GameService],
+  exports: [GameService],
+})
+export class GameModule {}

--- a/service/src/game/game.service.ts
+++ b/service/src/game/game.service.ts
@@ -1,0 +1,231 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { GameSessionRepository } from "../database/game-session.repository";
+import { GameRollRepository } from "../database/game-roll.repository";
+import { UserRepository } from "../database/user.repository";
+import { RollSymbol } from "../database/entities/game-roll.entity";
+import { User } from "../database/entities/user.entity";
+import { SessionResponseDto } from "./dto/session-response.dto";
+import { RollResponseDto } from "./dto/roll-response.dto";
+import { CashoutResponseDto } from "./dto/cashout-response.dto";
+import { CheatingConfig } from "../config/app.config";
+
+@Injectable()
+export class GameService {
+  constructor(
+    private readonly gameSessionRepository: GameSessionRepository,
+    private readonly gameRollRepository: GameRollRepository,
+    private readonly userRepository: UserRepository,
+    private readonly configService: ConfigService
+  ) {}
+
+  async startSession(user: User): Promise<SessionResponseDto> {
+    const existingSession = this.gameSessionRepository.findUserActiveSession(
+      user.id
+    );
+    if (existingSession) {
+      throw new BadRequestException("User already has an active session");
+    }
+
+    const sessionStartingCredits = this.configService.get(
+      "app.game.sessionStartingCredits"
+    );
+
+    if (user.gameCredits < sessionStartingCredits) {
+      throw new BadRequestException("Insufficient credits to start session");
+    }
+
+    this.userRepository.update(user.id, {
+      gameCredits: user.gameCredits - sessionStartingCredits,
+    });
+
+    const session = this.gameSessionRepository.create(
+      user.id,
+      sessionStartingCredits
+    );
+
+    return {
+      sessionId: session.id,
+      credits: session.credits,
+      isActive: session.isActive,
+      createdAt: session.createdAt,
+    };
+  }
+
+  async roll(sessionId: string, user: User): Promise<RollResponseDto> {
+    const session = this.gameSessionRepository.findById(sessionId);
+    if (!session || !session.isActive) {
+      throw new NotFoundException("Active session not found");
+    }
+
+    if (session.userId !== user.id) {
+      throw new ForbiddenException("You can only roll in your own session");
+    }
+
+    if (session.credits < 1) {
+      throw new BadRequestException("Insufficient credits to roll");
+    }
+
+    const creditsBefore = session.credits;
+    session.credits -= 1;
+
+    let { symbols, isWin, reward } = this.performRoll();
+    let wasRerolled = false;
+
+    const cheatingConfig = this.configService.get("app.game.cheating");
+    const shouldReroll =
+      isWin &&
+      cheatingConfig.enabled &&
+      this.shouldReroll(session.credits, cheatingConfig);
+
+    if (shouldReroll) {
+      wasRerolled = true;
+      ({ symbols, isWin, reward } = this.performRoll());
+    }
+
+    if (isWin) {
+      session.credits += reward;
+    }
+
+    const roll = this.gameRollRepository.create(
+      sessionId,
+      symbols,
+      isWin,
+      reward,
+      creditsBefore,
+      session.credits,
+      wasRerolled
+    );
+
+    return {
+      rollId: roll.id,
+      symbols: roll.symbols,
+      isWin: roll.isWin,
+      reward: roll.reward,
+      creditsBefore: roll.creditsBefore,
+      creditsAfter: roll.creditsAfter,
+      createdAt: roll.createdAt,
+    };
+  }
+
+  async cashout(sessionId: string, user: User): Promise<CashoutResponseDto> {
+    const session = this.gameSessionRepository.findById(sessionId);
+    if (!session || !session.isActive) {
+      throw new NotFoundException("Active session not found");
+    }
+
+    if (session.userId !== user.id) {
+      throw new ForbiddenException("You can only cash out your own session");
+    }
+
+    const cashedOutCredits = session.credits;
+
+    this.gameSessionRepository.closeSession(sessionId);
+    this.userRepository.update(user.id, {
+      gameCredits: user.gameCredits + cashedOutCredits,
+    });
+
+    return {
+      sessionId: session.id,
+      cashedOutCredits,
+      cashedOutAt: new Date(),
+    };
+  }
+
+  async getSession(sessionId: string, user: User): Promise<SessionResponseDto> {
+    const session = this.gameSessionRepository.findById(sessionId);
+    if (!session) {
+      throw new NotFoundException("Session not found");
+    }
+
+    if (session.userId !== user.id) {
+      throw new ForbiddenException("You can only view your own sessions");
+    }
+
+    return {
+      sessionId: session.id,
+      credits: session.credits,
+      isActive: session.isActive,
+      createdAt: session.createdAt,
+    };
+  }
+
+  async getSessionRolls(
+    sessionId: string,
+    user: User
+  ): Promise<RollResponseDto[]> {
+    const session = this.gameSessionRepository.findById(sessionId);
+    if (!session) {
+      throw new NotFoundException("Session not found");
+    }
+
+    if (session.userId !== user.id) {
+      throw new ForbiddenException("You can only view your own session rolls");
+    }
+
+    const rolls = this.gameRollRepository.findBySessionId(sessionId);
+    return rolls.map((roll) => ({
+      rollId: roll.id,
+      symbols: roll.symbols,
+      isWin: roll.isWin,
+      reward: roll.reward,
+      creditsBefore: roll.creditsBefore,
+      creditsAfter: roll.creditsAfter,
+      createdAt: roll.createdAt,
+    }));
+  }
+
+  private generateRandomSymbols(count: number): RollSymbol[] {
+    const symbols = Object.values(RollSymbol);
+    const result: RollSymbol[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const randomIndex = Math.floor(Math.random() * symbols.length);
+      result.push(symbols[randomIndex]);
+    }
+
+    return result;
+  }
+
+  private checkWin(symbols: RollSymbol[]): boolean {
+    return symbols[0] === symbols[1] && symbols[1] === symbols[2];
+  }
+
+  private performRoll(): {
+    symbols: RollSymbol[];
+    isWin: boolean;
+    reward: number;
+  } {
+    const symbolsCount = this.configService.get("app.game.symbolsCount");
+    const symbolRewards = this.configService.get("app.game.symbolRewards");
+
+    const symbols = this.generateRandomSymbols(symbolsCount);
+    const isWin = this.checkWin(symbols);
+    const reward = isWin ? symbolRewards[symbols[0]] : 0;
+    return { symbols, isWin, reward };
+  }
+
+  private shouldReroll(
+    credits: number,
+    cheatingConfig: CheatingConfig
+  ): boolean {
+    const applicableThresholds = cheatingConfig.thresholds.filter(
+      (threshold) => credits >= threshold.balance
+    );
+
+    if (applicableThresholds.length === 0) {
+      return false;
+    }
+
+    const maxChance = Math.max(
+      ...applicableThresholds.map((t) => t.rerollChance)
+    );
+
+    return Math.random() < maxChance;
+  }
+}


### PR DESCRIPTION
Added core game logic with next endpoints:

- Start new game session:
![Screenshot 2025-06-26 at 00 39 55](https://github.com/user-attachments/assets/f17dbdf3-55e6-4770-bf39-79715dd8d763)

- Perform session roll:
![Screenshot 2025-06-26 at 00 40 18](https://github.com/user-attachments/assets/2bbfdb04-0792-4644-8d49-f4f77c159f4e)

- Get session details:
![Screenshot 2025-06-26 at 00 40 55](https://github.com/user-attachments/assets/dc532ed3-936b-4593-a89e-9365ec89302b)

- Get session rolls:
![Screenshot 2025-06-26 at 00 41 33](https://github.com/user-attachments/assets/a160a1e3-060f-43b7-88cb-f272de50e064)

- Session cashout/close:
![Screenshot 2025-06-26 at 00 41 59](https://github.com/user-attachments/assets/9be5cb74-62ed-4bdb-aa28-393b58ea1255)


